### PR TITLE
Mentor session details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,7 @@ import MentorSessions from "./pages/Mentor/MentorSessions";
 import MentorContext from "./pages/Mentor/MentorContext";
 import StudentCohort from "./pages/Student/StudentCohort";
 import StudentSession from "./pages/Student/StudentSession";
+import MentorSession from "./pages/Mentor/SessionDetails";
 /*
     ==========================
     =    AUX MUI VARIABLES   =
@@ -195,6 +196,10 @@ const App = () => {
                 <Route
                   path="mentor/sessions"
                   element={<MentorSessions />}
+                ></Route>
+                <Route
+                  path="mentor/session/:sessionId"
+                  element={<MentorSession />}
                 ></Route>
               </Route>
             </Route>

--- a/src/pages/Home/MentorHome.jsx
+++ b/src/pages/Home/MentorHome.jsx
@@ -12,12 +12,13 @@ const MentorHome = () => {
   useEffect(() => {
     const fetchCohorts = async () => {
       try {
-        const res = await axiosPrivate.get("/users/cohorts", {});
-        if (res.data.cohorts.length === 1) {
-          const cohort = res.data.cohorts[0];
+        const res = await axiosPrivate.get("/profile");
+        if (res.data.profile.cohorts.length === 1) {
+          const cohort = res.data.profile.cohorts[0];
+          setSelectedCohort(cohort);
           navigate(`/cohort/${cohort._id}`, { state: cohort });
         }
-        setCohorts(res.data.cohorts);
+        setCohorts(res.data.profile.cohorts);
       } catch (err) {
         console.log(err);
       }

--- a/src/pages/Mentor/Cohort.jsx
+++ b/src/pages/Mentor/Cohort.jsx
@@ -10,7 +10,7 @@ import {
   CircularProgress,
 } from "@mui/material";
 import { useEffect, useState } from "react";
-import { useNavigate, useOutletContext } from "react-router-dom";
+import { Link, useNavigate, useOutletContext } from "react-router-dom";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
 
 const Cohort = () => {
@@ -96,7 +96,10 @@ const Cohort = () => {
               >
                 <Box>
                   <CardContent>
-                    <Typography variant="h5">{`${session.type} session`}</Typography>
+                    <Link to={`/mentor/session/${session._id}`}>
+                      {" "}
+                      {`${session.type} session`}
+                    </Link>
                     <Typography variant="subtitle1">
                       {new Date(session.start).toLocaleDateString()}
                     </Typography>

--- a/src/pages/Mentor/Cohort.jsx
+++ b/src/pages/Mentor/Cohort.jsx
@@ -10,11 +10,12 @@ import {
   CircularProgress,
 } from "@mui/material";
 import { useEffect, useState } from "react";
-import { useOutletContext } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
 
 const Cohort = () => {
   const [currentWeek, setCurrentWeek] = useState();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const axiosPrivate = useAxiosPrivate();
   const [cohort] = useOutletContext();
@@ -27,6 +28,9 @@ const Cohort = () => {
       setCurrentWeek(res.data.currentWeek);
       setLoading(false);
     };
+    if (!cohort) {
+      navigate("/mentor");
+    }
     getCurrentWeek();
   }, []);
 
@@ -51,7 +55,7 @@ const Cohort = () => {
             fontSize: 25,
           }}
         >
-          {/* {cohort.name} */}
+          {cohort?.name}
         </Typography>
       </Box>
       <Typography

--- a/src/pages/Mentor/SessionDetails.jsx
+++ b/src/pages/Mentor/SessionDetails.jsx
@@ -3,37 +3,23 @@ import {
   Container,
   Typography,
   List,
-  Card,
   CardContent,
-  Chip,
   ListItem,
-  ListItemText,
+  TextField,
+  Button,
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
-import { useNavigate } from "react-router-dom";
-import AuthFormControl from "../../components/FormControl/AuthFormControl";
-import FormTextField from "../../components/TextField/FormTextField";
-import AppButton from "../../components/Button/AppButton";
 import useAuth from "../../hooks/useAuth";
 
 const MentorSession = () => {
+  const { sessionId } = useParams();
+  const axiosPrivate = useAxiosPrivate();
+  const { auth } = useAuth();
   const [currentSession, setCurrentSession] = useState();
   const [loading, setLoading] = useState(true);
-  const axiosPrivate = useAxiosPrivate();
-  const navigate = useNavigate();
-  const { sessionId } = useParams();
-  const [reset, setReset] = useState(false);
-  //   const [userStatus, setUserStatus] = useState();
-  const { auth, setAuth } = useAuth();
   const [comment, setComment] = useState();
-  const [formError, setFormError] = useState({
-    commentError: {
-      error: false,
-      errorMessage: "Please enter a valid comment",
-    },
-  });
 
   const getCurrentSession = async () => {
     setLoading(true);
@@ -41,22 +27,6 @@ const MentorSession = () => {
     setCurrentSession(data.session);
     setLoading(false);
   };
-
-  console.log(currentSession);
-
-  //   const loggedInUserStatus = async () => {
-  //     setLoading(true);
-  //     const { data } = await axiosPrivate.get(
-  //       `/session/${sessionId}/student/status`
-  //     );
-  //     console.log(data);
-  //     if (data) {
-  //       setUserStatus("Confirm");
-  //     } else {
-  //       setUserStatus("Not Joining");
-  //     }
-  //     setLoading(false);
-  //   };
 
   const handleCommentSubmit = async (e) => {
     e.preventDefault();
@@ -66,37 +36,20 @@ const MentorSession = () => {
       content: e.target.comment.value.trim(),
       sessionId: sessionId,
     });
-    console.log(data);
+
+    const newComment = data.comment;
+    newComment.name = { _id: auth.userId, name: auth.userName };
+    const newSession = {
+      ...currentSession,
+      discussion: [...currentSession.discussion, newComment],
+    };
+    setCurrentSession(newSession);
     setComment("");
   };
 
-  // const getComment = async () => {
-  //   setLoading(true);
-  //   const { data } = await axiosPrivate.get("/session/comment");
-  //   console.log(data);
-  //   // setComment((prev)=>[...prev, data]);
-  //   setLoading(false);
-  // };
-
   useEffect(() => {
     getCurrentSession();
-    // loggedInUserStatus();
-    // getComment();
   }, [sessionId]);
-
-  const userStatus =
-    currentSession?.creator._id === auth.userId ||
-    currentSession?.participant?.includes(auth.userId);
-
-  const handleCommentError = (inputError) => {
-    setFormError((prevState) => ({
-      ...prevState,
-      commentError: {
-        ...prevState.commentError,
-        error: inputError,
-      },
-    }));
-  };
 
   const convertDate = (date) => {
     if (!date) {
@@ -123,7 +76,7 @@ const MentorSession = () => {
     return initials;
   };
 
-  const getRandomColor = () => {
+  const getColor = (name) => {
     const colors = [
       "#FFD4B2",
       "#FFF6BD",
@@ -132,8 +85,8 @@ const MentorSession = () => {
       "#FD8A8A",
       "#9EA1D4",
     ];
-    const i = Math.floor(Math.random() * colors.length);
-    return colors[i];
+    const letterNum = name[0].toLowerCase().charCodeAt(0) - 97;
+    return colors[letterNum % colors.length];
   };
 
   return (
@@ -141,7 +94,7 @@ const MentorSession = () => {
       {loading ? (
         <h1>Loading</h1>
       ) : (
-        <Container sx={{ backgroundColor: "#f2f2f2" }}>
+        <Container sx={{ backgroundColor: "#f2f2f2", marginBlock: 4 }}>
           <Typography component="h1" sx={{ fontSize: "2rem" }}>
             Session Details
           </Typography>
@@ -184,26 +137,6 @@ const MentorSession = () => {
             </Box>
           </Box>
 
-          <Box
-            sx={{
-              display: "flex",
-              gap: 1,
-              alignItems: "center",
-              marginBlock: 2,
-            }}
-          >
-            <Typography
-              component="h3"
-              sx={{ fontSize: "1.5rem", paddingBlock: 1 }}
-            >
-              Current status:
-            </Typography>
-            {userStatus ? (
-              <Chip label="Confirmed" color="success"></Chip>
-            ) : (
-              <Chip label="Not Confirmed" color="warning"></Chip>
-            )}
-          </Box>
           <Box>
             <Typography
               component="h3"
@@ -222,7 +155,7 @@ const MentorSession = () => {
                         height: "40px",
                         lineHeight: "40px",
                         textAlign: "center",
-                        backgroundColor: getRandomColor(),
+                        backgroundColor: getColor(student.name),
                       }}
                     >
                       {getInitials(student.name)}
@@ -237,18 +170,37 @@ const MentorSession = () => {
               <Typography>No students in this session at the moment</Typography>
             )}
           </Box>
-          <Box>
-            <Typography
-              component="h3"
-              sx={{ fontSize: "1.5rem", paddingBlock: 1 }}
-            >
-              Discussion:
-            </Typography>
+          <Typography
+            component="h3"
+            sx={{ fontSize: "1.5rem", paddingBlock: 1 }}
+          >
+            Discussion:
+          </Typography>
+
+          <Box
+            component="form"
+            autoComplete="off"
+            onSubmit={handleCommentSubmit}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+            }}
+          >
+            <TextField
+              required
+              type="text"
+              label="Add new comment"
+              name="comment"
+              value={comment}
+            ></TextField>
+            <Button type="submit">Add new comment</Button>
           </Box>
-          <List>
+
+          <List sx={{ backgroundColor: "#fefefe", marginBlockEnd: 4 }}>
             {currentSession?.discussion?.length > 0 ? (
               currentSession?.discussion.map((d) => (
-                <Card
+                <Box
                   key={d._id}
                   sx={{
                     display: "flex",
@@ -266,7 +218,7 @@ const MentorSession = () => {
                       <Typography>{d.name.name}</Typography>
                     </CardContent>
                   </Box>
-                </Card>
+                </Box>
               ))
             ) : (
               <Typography>No discussions in this session</Typography>
@@ -276,220 +228,6 @@ const MentorSession = () => {
       )}
     </>
   );
-  // return (
-  //   <Container>
-  //     <Box
-  //       sx={{
-  //         display: "flex",
-  //         justifyContent: "center",
-  //         bgcolor: "transparent",
-  //       }}
-  //     >
-  //       <Typography
-  //         component={"h1"}
-  //         sx={{
-  //           backgroundColor: "#C84B31",
-  //           borderRadius: 2,
-  //           padding: 2,
-  //           margin: 1,
-  //           textAlign: "center",
-  //           fontWeight: "bold",
-  //           fontSize: 25,
-  //         }}
-  //       >
-  //         {currentSession?.type} Session
-  //       </Typography>
-  //       <Typography
-  //         sx={{
-  //           backgroundColor: "#C84B31",
-  //           borderRadius: 2,
-  //           padding: 2,
-  //           margin: 1,
-  //           textAlign: "center",
-  //           fontWeight: "bold",
-  //           fontSize: 25,
-  //         }}
-  //       >
-  //         {currentSession?.creator.name}
-  //       </Typography>
-  //       <Typography
-  //         sx={{
-  //           backgroundColor: "#055c1c",
-  //           borderRadius: 2,
-  //           padding: 2,
-  //           margin: 1,
-  //           textAlign: "center",
-  //           fontWeight: "bold",
-  //           fontSize: 25,
-  //         }}
-  //       >
-  //         My Current Status: {userStatus ? "Confirmed" : "Not confirmed"}
-  //       </Typography>
-  //     </Box>
-  //     <Typography
-  //       sx={{
-  //         backgroundColor: "#ffffff",
-  //         borderRadius: 2,
-  //         padding: 1,
-  //         margin: 1,
-  //         textAlign: "center",
-  //         fontSize: 20,
-  //       }}
-  //     >
-  //       Start: {currentSession?.start}
-  //     </Typography>
-  //     <Typography
-  //       sx={{
-  //         backgroundColor: "#ffffff",
-  //         borderRadius: 2,
-  //         padding: 1,
-  //         margin: 1,
-  //         textAlign: "center",
-  //         fontSize: 20,
-  //       }}
-  //     >
-  //       End: {currentSession?.end}
-  //     </Typography>
-  //     <Typography
-  //       sx={{
-  //         backgroundColor: "#f2f2f2",
-  //         padding: 2,
-  //         borderRadius: 2,
-  //       }}
-  //     >
-  //       Confirmed participation:
-  //     </Typography>
-  //     <List>
-  //       {currentSession?.participant?.length > 0 ? (
-  //         currentSession?.participant.map((p) => (
-  //           <Card
-  //             key={p._id}
-  //             sx={{
-  //               display: "flex",
-  //               justifyContent: "space-between",
-  //               alignItems: "center",
-  //             }}
-  //           >
-  //             <Box>
-  //               <CardContent>
-  //                 <Typography variant="h5">{`${p.name}`}</Typography>
-  //               </CardContent>
-  //             </Box>
-  //           </Card>
-  //         ))
-  //       ) : (
-  //         <Typography
-  //           sx={{
-  //             backgroundColor: "#f2f2f2",
-  //             padding: 2,
-  //             borderRadius: 2,
-  //             textAlign: "center",
-  //           }}
-  //         >
-  //           No students in this session
-  //         </Typography>
-  //       )}
-  //     </List>
-  //     <br />
-  //     <br />
-
-  //     <Typography
-  //       component={"h1"}
-  //       sx={{
-  //         backgroundColor: "#C84B31",
-  //         borderRadius: 2,
-  //         padding: 2,
-  //         margin: 1,
-  //         textAlign: "center",
-  //         fontWeight: "bold",
-  //         fontSize: 25,
-  //       }}
-  //     >
-  //       Discussion
-  //     </Typography>
-
-  //     <Box
-  //       component={"form"}
-  //       sx={{
-  //         display: "flex",
-  //         flexDirection: "column",
-  //         justifyContent: "center",
-  //         alignItems: "center",
-  //         width: "100%",
-  //       }}
-  //       autoComplete="off"
-  //       onSubmit={handleCommentSubmit}
-  //     >
-  //       <div>
-  //         <AuthFormControl width="75%">
-  //           <Box
-  //             sx={{
-  //               display: "flex",
-  //               flexDirection: "column",
-  //               justifyContent: "center",
-  //             }}
-  //           >
-  //             <br></br>
-  //           </Box>
-  //           <FormTextField
-  //             required
-  //             type="text"
-  //             label="Comment:"
-  //             name="comment"
-  //             isFocused={true}
-  //             width="100%"
-  //             variant="light"
-  //             reset={reset}
-  //             value={comment}
-  //             onHandleError={handleCommentError}
-  //           ></FormTextField>
-  //         </AuthFormControl>
-  //         <AppButton
-  //           text={"Add new comment"}
-  //           type="submit"
-  //           width="25%"
-  //           handlerFunction={() => {}}
-  //         />
-  //       </div>
-  //     </Box>
-  //     <List>
-  //       {currentSession?.discussion?.length > 0 ? (
-  //         currentSession?.discussion.map((d) => (
-  //           <Card
-  //             key={d._id}
-  //             sx={{
-  //               display: "flex",
-  //               justifyContent: "space-between",
-  //               alignItems: "center",
-  //             }}
-  //           >
-  //             <Box>
-  //               <CardContent>
-  //                 <Typography variant="h5">{`${d.content}`}</Typography>
-  //               </CardContent>
-  //             </Box>
-  //             <Box>
-  //               <CardContent>
-  //                 <Typography>{`${d.name.name}`}</Typography>
-  //               </CardContent>
-  //             </Box>
-  //           </Card>
-  //         ))
-  //       ) : (
-  //         <Typography
-  //           sx={{
-  //             backgroundColor: "#f2f2f2",
-  //             padding: 2,
-  //             borderRadius: 2,
-  //             textAlign: "center",
-  //           }}
-  //         >
-  //           No discussions in this session
-  //         </Typography>
-  //       )}
-  //     </List>
-  //   </Container>
-  // );
 };
 
 export default MentorSession;

--- a/src/pages/Mentor/SessionDetails.jsx
+++ b/src/pages/Mentor/SessionDetails.jsx
@@ -1,0 +1,495 @@
+import {
+  Box,
+  Container,
+  Typography,
+  List,
+  Card,
+  CardContent,
+  Chip,
+  ListItem,
+  ListItemText,
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import useAxiosPrivate from "../../hooks/useAxiosPrivate";
+import { useNavigate } from "react-router-dom";
+import AuthFormControl from "../../components/FormControl/AuthFormControl";
+import FormTextField from "../../components/TextField/FormTextField";
+import AppButton from "../../components/Button/AppButton";
+import useAuth from "../../hooks/useAuth";
+
+const MentorSession = () => {
+  const [currentSession, setCurrentSession] = useState();
+  const [loading, setLoading] = useState(true);
+  const axiosPrivate = useAxiosPrivate();
+  const navigate = useNavigate();
+  const { sessionId } = useParams();
+  const [reset, setReset] = useState(false);
+  //   const [userStatus, setUserStatus] = useState();
+  const { auth, setAuth } = useAuth();
+  const [comment, setComment] = useState();
+  const [formError, setFormError] = useState({
+    commentError: {
+      error: false,
+      errorMessage: "Please enter a valid comment",
+    },
+  });
+
+  const getCurrentSession = async () => {
+    setLoading(true);
+    const { data } = await axiosPrivate.get(`/session/${sessionId}`);
+    setCurrentSession(data.session);
+    setLoading(false);
+  };
+
+  console.log(currentSession);
+
+  //   const loggedInUserStatus = async () => {
+  //     setLoading(true);
+  //     const { data } = await axiosPrivate.get(
+  //       `/session/${sessionId}/student/status`
+  //     );
+  //     console.log(data);
+  //     if (data) {
+  //       setUserStatus("Confirm");
+  //     } else {
+  //       setUserStatus("Not Joining");
+  //     }
+  //     setLoading(false);
+  //   };
+
+  const handleCommentSubmit = async (e) => {
+    e.preventDefault();
+
+    const { data } = await axiosPrivate.post("/session/comment", {
+      name: auth.userName,
+      content: e.target.comment.value.trim(),
+      sessionId: sessionId,
+    });
+    console.log(data);
+    setComment("");
+  };
+
+  // const getComment = async () => {
+  //   setLoading(true);
+  //   const { data } = await axiosPrivate.get("/session/comment");
+  //   console.log(data);
+  //   // setComment((prev)=>[...prev, data]);
+  //   setLoading(false);
+  // };
+
+  useEffect(() => {
+    getCurrentSession();
+    // loggedInUserStatus();
+    // getComment();
+  }, [sessionId]);
+
+  const userStatus =
+    currentSession?.creator._id === auth.userId ||
+    currentSession?.participant?.includes(auth.userId);
+
+  const handleCommentError = (inputError) => {
+    setFormError((prevState) => ({
+      ...prevState,
+      commentError: {
+        ...prevState.commentError,
+        error: inputError,
+      },
+    }));
+  };
+
+  const convertDate = (date) => {
+    if (!date) {
+      return;
+    }
+    const auxDate = new Date(date);
+    const i = new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      timeZoneName: "short",
+    });
+    return i.format(auxDate);
+  };
+
+  const getInitials = (name) => {
+    const words = name.split(" ");
+    let initials = "";
+    for (let w of words) {
+      initials += w[0].toUpperCase();
+    }
+    return initials;
+  };
+
+  const getRandomColor = () => {
+    const colors = [
+      "#FFD4B2",
+      "#FFF6BD",
+      "#CEEDC7",
+      "#86C8BC",
+      "#FD8A8A",
+      "#9EA1D4",
+    ];
+    const i = Math.floor(Math.random() * colors.length);
+    return colors[i];
+  };
+
+  return (
+    <>
+      {loading ? (
+        <h1>Loading</h1>
+      ) : (
+        <Container sx={{ backgroundColor: "#f2f2f2" }}>
+          <Typography component="h1" sx={{ fontSize: "2rem" }}>
+            Session Details
+          </Typography>
+
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-around",
+              alignItems: "center",
+              paddingBlock: 1,
+            }}
+          >
+            <Box>
+              <Typography sx={{ fontSize: "1.2rem" }}>
+                {convertDate(currentSession?.start)}
+              </Typography>
+              <Typography sx={{ fontSize: "0.9rem", fontStyle: "italic" }}>
+                Duration: 60 minutes
+              </Typography>
+            </Box>
+            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+              <Typography
+                sx={{
+                  borderRadius: "50%",
+                  width: "40px",
+                  height: "40px",
+                  padding: 1,
+                  lineHeight: "40px",
+                  textAlign: "center",
+                  fontSize: "1.2rem",
+                  backgroundColor: "cornflowerblue",
+                }}
+              >
+                {getInitials(currentSession?.creator.name)}
+              </Typography>
+              <Box>
+                <Typography>{"Mentor:"}</Typography>
+                <Typography>{currentSession?.creator.name}</Typography>
+              </Box>
+            </Box>
+          </Box>
+
+          <Box
+            sx={{
+              display: "flex",
+              gap: 1,
+              alignItems: "center",
+              marginBlock: 2,
+            }}
+          >
+            <Typography
+              component="h3"
+              sx={{ fontSize: "1.5rem", paddingBlock: 1 }}
+            >
+              Current status:
+            </Typography>
+            {userStatus ? (
+              <Chip label="Confirmed" color="success"></Chip>
+            ) : (
+              <Chip label="Not Confirmed" color="warning"></Chip>
+            )}
+          </Box>
+          <Box>
+            <Typography
+              component="h3"
+              sx={{ fontSize: "1.5rem", paddingBlock: 1 }}
+            >
+              Confirmed Participants:
+            </Typography>
+            {currentSession?.participant.length > 0 ? (
+              <List>
+                {currentSession?.participant.map((student) => (
+                  <ListItem key={student._id}>
+                    <Typography
+                      sx={{
+                        borderRadius: "50%",
+                        width: "40px",
+                        height: "40px",
+                        lineHeight: "40px",
+                        textAlign: "center",
+                        backgroundColor: getRandomColor(),
+                      }}
+                    >
+                      {getInitials(student.name)}
+                    </Typography>
+                    <Typography sx={{ paddingLeft: "8px" }}>
+                      {student.name}
+                    </Typography>
+                  </ListItem>
+                ))}
+              </List>
+            ) : (
+              <Typography>No students in this session at the moment</Typography>
+            )}
+          </Box>
+          <Box>
+            <Typography
+              component="h3"
+              sx={{ fontSize: "1.5rem", paddingBlock: 1 }}
+            >
+              Discussion:
+            </Typography>
+          </Box>
+          <List>
+            {currentSession?.discussion?.length > 0 ? (
+              currentSession?.discussion.map((d) => (
+                <Card
+                  key={d._id}
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <Box>
+                    <CardContent>
+                      <Typography>{d.content}</Typography>
+                    </CardContent>
+                  </Box>
+                  <Box>
+                    <CardContent>
+                      <Typography>{d.name.name}</Typography>
+                    </CardContent>
+                  </Box>
+                </Card>
+              ))
+            ) : (
+              <Typography>No discussions in this session</Typography>
+            )}
+          </List>
+        </Container>
+      )}
+    </>
+  );
+  // return (
+  //   <Container>
+  //     <Box
+  //       sx={{
+  //         display: "flex",
+  //         justifyContent: "center",
+  //         bgcolor: "transparent",
+  //       }}
+  //     >
+  //       <Typography
+  //         component={"h1"}
+  //         sx={{
+  //           backgroundColor: "#C84B31",
+  //           borderRadius: 2,
+  //           padding: 2,
+  //           margin: 1,
+  //           textAlign: "center",
+  //           fontWeight: "bold",
+  //           fontSize: 25,
+  //         }}
+  //       >
+  //         {currentSession?.type} Session
+  //       </Typography>
+  //       <Typography
+  //         sx={{
+  //           backgroundColor: "#C84B31",
+  //           borderRadius: 2,
+  //           padding: 2,
+  //           margin: 1,
+  //           textAlign: "center",
+  //           fontWeight: "bold",
+  //           fontSize: 25,
+  //         }}
+  //       >
+  //         {currentSession?.creator.name}
+  //       </Typography>
+  //       <Typography
+  //         sx={{
+  //           backgroundColor: "#055c1c",
+  //           borderRadius: 2,
+  //           padding: 2,
+  //           margin: 1,
+  //           textAlign: "center",
+  //           fontWeight: "bold",
+  //           fontSize: 25,
+  //         }}
+  //       >
+  //         My Current Status: {userStatus ? "Confirmed" : "Not confirmed"}
+  //       </Typography>
+  //     </Box>
+  //     <Typography
+  //       sx={{
+  //         backgroundColor: "#ffffff",
+  //         borderRadius: 2,
+  //         padding: 1,
+  //         margin: 1,
+  //         textAlign: "center",
+  //         fontSize: 20,
+  //       }}
+  //     >
+  //       Start: {currentSession?.start}
+  //     </Typography>
+  //     <Typography
+  //       sx={{
+  //         backgroundColor: "#ffffff",
+  //         borderRadius: 2,
+  //         padding: 1,
+  //         margin: 1,
+  //         textAlign: "center",
+  //         fontSize: 20,
+  //       }}
+  //     >
+  //       End: {currentSession?.end}
+  //     </Typography>
+  //     <Typography
+  //       sx={{
+  //         backgroundColor: "#f2f2f2",
+  //         padding: 2,
+  //         borderRadius: 2,
+  //       }}
+  //     >
+  //       Confirmed participation:
+  //     </Typography>
+  //     <List>
+  //       {currentSession?.participant?.length > 0 ? (
+  //         currentSession?.participant.map((p) => (
+  //           <Card
+  //             key={p._id}
+  //             sx={{
+  //               display: "flex",
+  //               justifyContent: "space-between",
+  //               alignItems: "center",
+  //             }}
+  //           >
+  //             <Box>
+  //               <CardContent>
+  //                 <Typography variant="h5">{`${p.name}`}</Typography>
+  //               </CardContent>
+  //             </Box>
+  //           </Card>
+  //         ))
+  //       ) : (
+  //         <Typography
+  //           sx={{
+  //             backgroundColor: "#f2f2f2",
+  //             padding: 2,
+  //             borderRadius: 2,
+  //             textAlign: "center",
+  //           }}
+  //         >
+  //           No students in this session
+  //         </Typography>
+  //       )}
+  //     </List>
+  //     <br />
+  //     <br />
+
+  //     <Typography
+  //       component={"h1"}
+  //       sx={{
+  //         backgroundColor: "#C84B31",
+  //         borderRadius: 2,
+  //         padding: 2,
+  //         margin: 1,
+  //         textAlign: "center",
+  //         fontWeight: "bold",
+  //         fontSize: 25,
+  //       }}
+  //     >
+  //       Discussion
+  //     </Typography>
+
+  //     <Box
+  //       component={"form"}
+  //       sx={{
+  //         display: "flex",
+  //         flexDirection: "column",
+  //         justifyContent: "center",
+  //         alignItems: "center",
+  //         width: "100%",
+  //       }}
+  //       autoComplete="off"
+  //       onSubmit={handleCommentSubmit}
+  //     >
+  //       <div>
+  //         <AuthFormControl width="75%">
+  //           <Box
+  //             sx={{
+  //               display: "flex",
+  //               flexDirection: "column",
+  //               justifyContent: "center",
+  //             }}
+  //           >
+  //             <br></br>
+  //           </Box>
+  //           <FormTextField
+  //             required
+  //             type="text"
+  //             label="Comment:"
+  //             name="comment"
+  //             isFocused={true}
+  //             width="100%"
+  //             variant="light"
+  //             reset={reset}
+  //             value={comment}
+  //             onHandleError={handleCommentError}
+  //           ></FormTextField>
+  //         </AuthFormControl>
+  //         <AppButton
+  //           text={"Add new comment"}
+  //           type="submit"
+  //           width="25%"
+  //           handlerFunction={() => {}}
+  //         />
+  //       </div>
+  //     </Box>
+  //     <List>
+  //       {currentSession?.discussion?.length > 0 ? (
+  //         currentSession?.discussion.map((d) => (
+  //           <Card
+  //             key={d._id}
+  //             sx={{
+  //               display: "flex",
+  //               justifyContent: "space-between",
+  //               alignItems: "center",
+  //             }}
+  //           >
+  //             <Box>
+  //               <CardContent>
+  //                 <Typography variant="h5">{`${d.content}`}</Typography>
+  //               </CardContent>
+  //             </Box>
+  //             <Box>
+  //               <CardContent>
+  //                 <Typography>{`${d.name.name}`}</Typography>
+  //               </CardContent>
+  //             </Box>
+  //           </Card>
+  //         ))
+  //       ) : (
+  //         <Typography
+  //           sx={{
+  //             backgroundColor: "#f2f2f2",
+  //             padding: 2,
+  //             borderRadius: 2,
+  //             textAlign: "center",
+  //           }}
+  //         >
+  //           No discussions in this session
+  //         </Typography>
+  //       )}
+  //     </List>
+  //   </Container>
+  // );
+};
+
+export default MentorSession;

--- a/src/pages/Mentor/SessionDetails.jsx
+++ b/src/pages/Mentor/SessionDetails.jsx
@@ -19,7 +19,7 @@ const MentorSession = () => {
   const { auth } = useAuth();
   const [currentSession, setCurrentSession] = useState();
   const [loading, setLoading] = useState(true);
-  const [comment, setComment] = useState();
+  const [comment, setComment] = useState("");
 
   const getCurrentSession = async () => {
     setLoading(true);
@@ -94,7 +94,9 @@ const MentorSession = () => {
       {loading ? (
         <h1>Loading</h1>
       ) : (
-        <Container sx={{ backgroundColor: "#f2f2f2", marginBlock: 4 }}>
+        <Container
+          sx={{ backgroundColor: "#f2f2f2", marginBlock: 4, borderRadius: 2 }}
+        >
           <Typography component="h1" sx={{ fontSize: "2rem" }}>
             Session Details
           </Typography>
@@ -182,9 +184,7 @@ const MentorSession = () => {
             autoComplete="off"
             onSubmit={handleCommentSubmit}
             sx={{
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
+              alignItems: "center",
             }}
           >
             <TextField
@@ -193,11 +193,30 @@ const MentorSession = () => {
               label="Add new comment"
               name="comment"
               value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              sx={{ display: "flex" }}
             ></TextField>
-            <Button type="submit">Add new comment</Button>
+            <Box
+              sx={{ display: "flex", justifyContent: "center", marginBlock: 1 }}
+            >
+              <Button
+                type="submit"
+                sx={{
+                  color: "white",
+                  backgroundColor: "#C84B31",
+                  "&:hover": {
+                    backgroundColor: "#C84B31",
+                    transform: "scale(1.05)",
+                    transition: "all 0.2s ease-in-out",
+                  },
+                }}
+              >
+                Add new Comment
+              </Button>
+            </Box>
           </Box>
 
-          <List sx={{ backgroundColor: "#fefefe", marginBlockEnd: 4 }}>
+          <List sx={{ marginBlockEnd: 4 }}>
             {currentSession?.discussion?.length > 0 ? (
               currentSession?.discussion.map((d) => (
                 <Box
@@ -206,6 +225,9 @@ const MentorSession = () => {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    marginBlockEnd: 1,
+                    backgroundColor: "#fefefe",
+                    borderRadius: 2,
                   }}
                 >
                   <Box>


### PR DESCRIPTION
This PR adds:

1. Makes sure that the `mentorContext` is properly populated in the pages that it is required (navigates back to the mentor homepage otherwise);
2. Updates the URL to get the cohorts of a mentor to match the new API endpoint;
3. Adds the details of a session: mentors will see the details of a session, the confirmed participants and the discussion. I ended up creating a different interface, let me know what you think! For reference:

![image](https://github.com/Code-the-Dream-School/dd-prac-team2-front/assets/55894222/4b3c099b-f15c-4abe-a5e9-a4eecc870c83)
