### PR TITLE
Move to the next/following weeks

### DIFF
--- a/src/pages/Mentor/Cohort.jsx
+++ b/src/pages/Mentor/Cohort.jsx
@@ -8,10 +8,12 @@ import {
   CardActions,
   Button,
   CircularProgress,
+  IconButton,
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useOutletContext } from "react-router-dom";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
+import { NavigateBefore, NavigateNext } from "@mui/icons-material";
 
 const Cohort = () => {
   const [currentWeek, setCurrentWeek] = useState();
@@ -33,6 +35,27 @@ const Cohort = () => {
     }
     getCurrentWeek();
   }, []);
+
+  const getWeek = async (index) => {
+    setLoading(true);
+    const res = await axiosPrivate.get(`/week/${cohort._id}/index/${index}`);
+    setCurrentWeek(res.data.populatedWeek);
+    setLoading(false);
+  };
+
+  const handleNextWeek = () => {
+    if (currentWeek.end === cohort.end) {
+      return;
+    }
+    getWeek(currentWeek.index + 1);
+  };
+
+  const handlePreviousWeek = () => {
+    if (currentWeek.index === 0) {
+      return;
+    }
+    getWeek(currentWeek.index - 1);
+  };
 
   return (
     <Container>
@@ -58,19 +81,33 @@ const Cohort = () => {
           {cohort?.name}
         </Typography>
       </Box>
-      <Typography
+      <Box
         sx={{
           backgroundColor: "#C84B31",
+          display: "flex",
+          justifyContent: "space-between",
           borderRadius: 2,
-          padding: 1,
-          margin: 1,
-          textAlign: "center",
-          fontWeight: "bold",
-          fontSize: 25,
         }}
       >
-        {currentWeek?.name}
-      </Typography>
+        <IconButton onClick={handlePreviousWeek}>
+          <NavigateBefore fontSize="large" />
+        </IconButton>
+        <Typography
+          sx={{
+            padding: 1,
+            margin: 1,
+            textAlign: "center",
+            fontWeight: "bold",
+            fontSize: 25,
+            flexGrow: 1,
+          }}
+        >
+          {currentWeek?.name}
+        </Typography>
+        <IconButton onClick={handleNextWeek}>
+          <NavigateNext fontSize="large" />
+        </IconButton>
+      </Box>
       {loading ? (
         <Box
           sx={{


### PR DESCRIPTION
In the mentor page, now mentors can navigate between the different weeks of a cohort.

This requires the latest Cohort schema in the back end, so to test it create a new cohort first.