### PR TITLE
Fixes how data is saved in the auth context

### DIFF
--- a/src/hooks/useRefreshToken.js
+++ b/src/hooks/useRefreshToken.js
@@ -36,7 +36,7 @@ const useRefreshToken = () => {
         slackId: response.data.user.slackId ?? "",
         userName: response.data.user.name,
         userEmail: response.data.user.email,
-        role: response.data.user.roles,
+        role: response.data.user.role,
         loggedIn: true,
         avatarUrl: response.data.user.avatarUrl ?? "",
         isActive: response.data.user.isActivated,

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -41,7 +41,7 @@ const Login = () => {
         =        CONTEXT         =
         ==========================
     */
-  const {auth, setAuth } = useAuth();
+  const { auth, setAuth } = useAuth();
   /*
         ==========================
         =         STATES         =
@@ -93,7 +93,7 @@ const Login = () => {
           slackId: response.data.user.slackId ?? "",
           userName: response.data.user.name,
           userEmail: response.data.user.email,
-          role: response.data.user.roles,
+          role: response.data.user.role,
           loggedIn: true,
           avatarUrl: response.data.user.avatarUrl ?? "",
           isActive: response.data.user.isActivated,
@@ -243,9 +243,7 @@ const Login = () => {
                   isFocused={false}
                   width="100%"
                   variant="light"
-                  errorMessage={
-                    "This field is required"
-                  }
+                  errorMessage={"This field is required"}
                   onHandleError={handlePasswordError}
                   reset={reset}
                 ></FormTextField>


### PR DESCRIPTION
PR #53 changed the user data we saved in the auth context. The user roles comes from the back-end as the property `user.role`. In #53, the auth object is accessing the property `user.roles`, which is undefined. This breaks the app, since the roles array is required in several pages.

I agree that `user.roles` is a better name, but we still need to refactor that in the back end. While we don't, let's revert to the old name.