### PR TITLE
Adds cohort name to session

### DIFF
--- a/src/pages/Mentor/CreateSession.jsx
+++ b/src/pages/Mentor/CreateSession.jsx
@@ -36,6 +36,7 @@ function CreateSession({ updateSessions, onLoading, onToast }) {
       link: "https://us02web.zoom.us/j/88579364493?pwd=loNkjaIa9sJA9slajs2jY5dz09",
       cohortId: cohort._id,
       multipleSessions: shouldRepeat,
+      cohortName: cohort.name,
     });
     onToast({
       isOpened: true,

--- a/src/pages/Mentor/MentorSession/MentorSessions.jsx
+++ b/src/pages/Mentor/MentorSession/MentorSessions.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import useAxiosPrivate from "../../../hooks/useAxiosPrivate";
-import { Box, Typography, Container } from "@mui/material";
+import { Box, Typography, Container, Chip } from "@mui/material";
 import CreateSession from "../CreateSession";
 import AppDataGrid from "../../../components/DataGrid/AppDataGrid";
 import MentorSessionsTableActions from "./Actions/MentorSessionsActions";
@@ -31,6 +31,7 @@ function MentorSessions() {
     return {
       id: session._id,
       date: session.start,
+      cohort: session.cohortName,
     };
   };
 
@@ -68,6 +69,22 @@ function MentorSessions() {
       headerName: "DATE",
       flex: 4,
       valueFormatter: (params) => getFormattedDate(params.value),
+    },
+    {
+      field: "cohort",
+      headerName: "COHORT",
+      flex: 1,
+      renderCell: (params) => (
+        <Chip
+          sx={{
+            backgroundColor: "#0F3460",
+            color: "white",
+            fontWeight: "bold",
+            textTransform: "capitalize",
+          }}
+          label={params.value}
+        ></Chip>
+      ),
     },
     {
       field: "actions",


### PR DESCRIPTION
The data grid now also displays the cohort associated to each session.

This is not backwards compatible and only works will new sessions. Old sessions will be removed soon.

The updated data grid now looks like this:

![Screenshot from 2023-09-10 22-06-13](https://github.com/Code-the-Dream-School/dd-prac-team2-front/assets/55894222/2b86371e-5d24-4132-9f6a-a3ff4a490a2f)
